### PR TITLE
Add Last-Modified to headers passed from origin

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -208,14 +208,17 @@ describe('Connection', function() {
                     'content-type': 'image/jpeg',
                     'content-length': '4833',
                     'server': 'Apache',
-                    'connection': 'keep-alive'
+                    'connection': 'keep-alive',
+                    'last-modified': 'Mon, 18 Apr 2016 12:00:00 GMT'
                 },
                 statusCode: 200
             };
         });
 
         it('cleans up the response headers', function() {
-            var goodKeys = ['Content-Length', 'Content-Type', 'Date'];
+            var goodKeys = [
+                'Content-Length', 'Content-Type', 'Date', 'Last-Modified'
+            ];
             c.handleImageResponse(imgResponse);
             expect(imgResponse.headers).to.only.have.keys(goodKeys);
         });

--- a/thumbp.js
+++ b/thumbp.js
@@ -142,11 +142,13 @@ Connection.prototype.handleImageResponse = function(imgResponse) {
     // Reduce headers to just those that we want to pass through
     var cl = imgResponse.headers['content-length'] || '0';
     var ct = imgResponse.headers['content-type'] || false;
+    var lm = imgResponse.headers['last-modified'] || false;
     imgResponse.headers = {
         'Date': imgResponse.headers['date'],
         'Content-Length': cl
     };
     ct && (imgResponse.headers['Content-Type'] = ct);
+    lm && (imgResponse.headers['Last-Modified'] = lm);
 
     // We have our own ideas of which response codes are appropriate for our
     // client.


### PR DESCRIPTION
Add Last-Modified from the headers present in the origin server's response that we pass along to our client (the proxy server), allowing the downstream client to make If-Modified-Since requests to the proxy server.

I've observed in a staging environment that, given a provider image that was served with a Last-Modified header, a page reload in my browser will issue the second request with an If-Modified-Since header. NGINX replies with a 304 and my browser uses its cached copy.
