### PR TITLE
Let Content-Length be undefined if not given

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -244,9 +244,9 @@ describe('Connection', function() {
             };
         });
 
-        it('assigns Content-Length 0 if it is not given', function() {
+        it('leaves Content-Length out if it is not given', function() {
             c.handleImageResponse(imgResponse);
-            expect(imgResponse.headers['Content-Length']).to.equal('0');
+            expect(imgResponse.headers['Content-Length']).to.be.undefined;
         });
 
         it('leaves Content-Type out if it is not given', function() {

--- a/thumbp.js
+++ b/thumbp.js
@@ -140,13 +140,13 @@ Connection.prototype.proxyImage = function() {
  */
 Connection.prototype.handleImageResponse = function(imgResponse) {
     // Reduce headers to just those that we want to pass through
-    var cl = imgResponse.headers['content-length'] || '0';
+    var cl = imgResponse.headers['content-length'] || false;
     var ct = imgResponse.headers['content-type'] || false;
     var lm = imgResponse.headers['last-modified'] || false;
     imgResponse.headers = {
         'Date': imgResponse.headers['date'],
-        'Content-Length': cl
     };
+    cl && (imgResponse.headers['Content-Length'] = cl);
     ct && (imgResponse.headers['Content-Type'] = ct);
     lm && (imgResponse.headers['Last-Modified'] = lm);
 


### PR DESCRIPTION
Stop forcing `Content-Length` to 0 if it is not given in the origin's response. Setting it to 0 causes the response body not to be piped through.

https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html says that `Content-Length` is "SHOULD," not "MUST."
