### PR TITLE
Improve error messages for failed resources

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -327,6 +327,7 @@ describe('Connection', function() {
         var error;
 
         beforeEach(function() {
+            c.imageURL = 'http://example.org/img.jpg';
             error = {
                 code: 'ECONNREFUSED'
             };
@@ -334,7 +335,8 @@ describe('Connection', function() {
 
         it('logs errors', function() {
             c.handleImageConnectionError(error);
-            assert(consoleErrorStub.calledWith(error));
+            msg = 'Error (ECONNREFUSED) for http://example.org/img.jpg';
+            assert(consoleErrorStub.calledWith(msg));
         });
 
         it('returns a 504 Gateway Timeout for a timeout', function() {

--- a/thumbp.js
+++ b/thumbp.js
@@ -192,7 +192,7 @@ Connection.prototype.handleImageResponse = function(imgResponse) {
  * Handle errors with the HTTP connection to the image webserver.
  */
 Connection.prototype.handleImageConnectionError = function(error) {
-    console.error(error);
+    console.error(`Error (${error.code}) for ${this.imageURL}`);
     if (error.code === 'ETIMEDOUT') {
         this.returnError(504);
     } else {


### PR DESCRIPTION
When logging an error, report the URL of the resource in addition to the error code.